### PR TITLE
secret value string

### DIFF
--- a/lib/redshift_serverless_namespace_stack.py
+++ b/lib/redshift_serverless_namespace_stack.py
@@ -25,7 +25,7 @@ class RedshiftServerlessNamespaceStack(cdk.Stack):
         namespace_configuration = {
             "namespace_name": namespace_name,
             "admin_username": REDSHIFT_DEFAULT_USER,
-            "admin_user_password": secret.secret_value.to_string(),
+            "admin_user_password": secret.secret_value.unsafe_plain_text(),
             "db_name": REDSHIFT_DEFAULT_DATABASE,
             "default_iam_role_arn": role.role_arn,
             "log_exports": ["useractivitylog"],

--- a/lib/redshift_serverless_namespace_stack.py
+++ b/lib/redshift_serverless_namespace_stack.py
@@ -25,7 +25,7 @@ class RedshiftServerlessNamespaceStack(cdk.Stack):
         namespace_configuration = {
             "namespace_name": namespace_name,
             "admin_username": REDSHIFT_DEFAULT_USER,
-            "admin_user_password": secret.secret_value,
+            "admin_user_password": secret.secret_value.to_string(),
             "db_name": REDSHIFT_DEFAULT_DATABASE,
             "default_iam_role_arn": role.role_arn,
             "log_exports": ["useractivitylog"],


### PR DESCRIPTION
Hey @BranfordTGbieor it turns out that we need a string version of the password and the best way we have is with the method used. The "unsafe" part of the method according to documentation comes in because the value can be seen by anyone with access to the cloud formation template eventually generated in AWS. The other way to use secret manager is with resources that accept it's objects as parameters which unfortunately redshift serverless resources don't accept at the moment. 

An improvement to this would be to separate the generation + loading secret values as in the prerequisite scripts you showed me. 
