### PR TITLE
Retrieving secret

### DIFF
--- a/lib/redshift_serverless_namespace_stack.py
+++ b/lib/redshift_serverless_namespace_stack.py
@@ -25,7 +25,7 @@ class RedshiftServerlessNamespaceStack(cdk.Stack):
         namespace_configuration = {
             "namespace_name": namespace_name,
             "admin_username": REDSHIFT_DEFAULT_USER,
-            "admin_user_password": secret.secret_value.unsafe_plain_text(),
+            "admin_user_password": secret.secret_value.unsafe_unwrap(),
             "db_name": REDSHIFT_DEFAULT_DATABASE,
             "default_iam_role_arn": role.role_arn,
             "log_exports": ["useractivitylog"],


### PR DESCRIPTION
Good day @BranfordTGbieor this is completely on me.
I knew of the to_string() method but I was referred to the unsafe_plain_text() method by my IDE. I should have used the unsafe_unwrap() to retrieve that value because the former latter method is used for storing plain_text secrets. 

This PR resolves that. 